### PR TITLE
Clean arXiv abstract formatting

### DIFF
--- a/arxiv_scraper.py
+++ b/arxiv_scraper.py
@@ -137,7 +137,7 @@ def get_papers_from_arxiv_rss(area: str, config: Optional[dict]) -> List[Paper]:
         # strip html tags from summary
         summary = re.sub("<[^<]+?>", "", paper.summary)
         summary = unescape(re.sub("\n", " ", summary))
-        summary = re.sub(r"arXiv:\d+\.\d+v\d+ Announce Type: new Abstract: ", "", summary)
+        summary = re.sub(r"arXiv:\s*\d+\.\d+v\d+\s*(?:Announce Type:\s*(?:new|replace|cross|withdraw)\s*)?Abstract:\s*", "", summary)
         # strip the last pair of parentehses containing (arXiv:xxxx.xxxxx [area.XX])
         title = re.sub("\(arXiv:[0-9]+\.[0-9]+v[0-9]+ \[.*\]\)$", "", paper.title)
         # remove the link part of the id

--- a/arxiv_scraper.py
+++ b/arxiv_scraper.py
@@ -137,6 +137,7 @@ def get_papers_from_arxiv_rss(area: str, config: Optional[dict]) -> List[Paper]:
         # strip html tags from summary
         summary = re.sub("<[^<]+?>", "", paper.summary)
         summary = unescape(re.sub("\n", " ", summary))
+        summary = re.sub(r"arXiv:\d+\.\d+v\d+ Announce Type: new Abstract: ", "", summary)
         # strip the last pair of parentehses containing (arXiv:xxxx.xxxxx [area.XX])
         title = re.sub("\(arXiv:[0-9]+\.[0-9]+v[0-9]+ \[.*\]\)$", "", paper.title)
         # remove the link part of the id


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove arXiv metadata prefix from paper abstracts


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arxiv_scraper.py</strong><dd><code>Clean arXiv abstract text formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

arxiv_scraper.py

<li>Added regex pattern to remove 'arXiv:XXXX.XXXXXvX Announce Type: new <br>Abstract:' prefix from paper summaries


</details>


  </td>
  <td><a href="https://github.com/DylanLIiii/AI_paper_collection_assistant/pull/2/files#diff-4df372ca8e485a1c5b16a503eef8781be47ff1b3d87c8e8d968718caff99d808">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information